### PR TITLE
Create means to flat cpollo contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 
 # truffle
 .node-xmlhttprequest-*
+
+# Flat Contract Files
+contracts/**/*Flat.sol

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "console": "truffle console",
     "coverage": "scripts/coverage.sh",
     "version": "scripts/version.js",
-    "deploy:testnet": "truffle exec scripts/deployTestnet.js --network ropsten"
+    "deploy:testnet": "truffle exec scripts/deployTestnet.js --network ropsten",
+    "flat-contracts": "sol-merger --append \"Flat\" \"./contracts/**/*.sol\""
   },
   "repository": {
     "type": "git",
@@ -51,6 +52,7 @@
     "eslint-plugin-standard": "^3.1.0",
     "ethjs-abi": "^0.2.1",
     "ganache-cli": "6.1.0",
+    "sol-merger": "^0.1.2",
     "solidity-coverage": "^0.5.4",
     "solium": "^1.1.8",
     "truffle": "^4.1.13",


### PR DESCRIPTION
This was made to make easy to flat solidity contracts to use them on eth network. But some notes should be taken.

As you can see on the npm script, the flat contracts are being generated in the same folder of the original contracts, this was done on purporse, with this `sol-merger` (the tool that will do the flat), can find the imports used on each contract and do what we espected.

When we compile the contracts with the `truffle`, he will generate the json files for the two contracts, the flat one and the original, however, because he generate the json file for the original contract first, he will ovewrite it respective version for the flat contract.
